### PR TITLE
feature-requesr: css-opt-menu

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -250,9 +250,11 @@ whodocs.html: _whodocs.html $(MAINPARTS)
 libs.html: _libs.html $(MAINPARTS)
 	$(ACTION)
 
-manpage.html: _manpage.html $(MAINPARTS) mandump.gen $(ROOT)/manpage.t
-	perl generatemanmenu.pl $(DOCROOT)/cmdline-opts > _manoptionsdump.html
+manpage.html: _manpage.html $(MAINPARTS) manoptionsdump.gen mandump.gen $(ROOT)/manpage.t
 	$(ACTION)
+
+manoptionsdump.gen:
+	perl generatemanmenu.pl $(DOCROOT)/cmdline-opts > manoptionsdump.gen
 
 curl.1: ../cvssource/docs/cmdline-opts/*.d
 	(cd ../cvssource/docs/cmdline-opts && perl gen.pl mainpage *.d) > curl.1

--- a/docs/_manpage.html
+++ b/docs/_manpage.html
@@ -12,7 +12,7 @@
 
 #include "_menu.html"
 #include "docs/_option-menu.html"
-#include "docs/_manoptionsdump.html"
+#include "docs/manoptionsdump.gen"
 #include "setup.t"
 
 WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", Man Page)

--- a/docs/_option-menu.html
+++ b/docs/_option-menu.html
@@ -50,9 +50,7 @@
  input.pinoptions:checked + label.pinoptions + div.dropdown-content {
      display: block;
      top: 40px;
-     left: 0px;
-     max-width: 300px;
-     min-height: 100px;
+     left: 0px;          
      margin-top: 10px;
      resize: both;
  }
@@ -60,7 +58,9 @@
  div#opt-dropdown.dropdown:hover div.dropdown-content,
  input.pinoptions:checked + label.pinoptions + div.dropdown-content {
      overflow-y: scroll;
-     max-height: 95vh;
+     max-height: 90vh; /* ensure browser shows bottom protion */
+     min-height: 100px;
+     max-width: 300px;
  }
  /* Add end marker puttting bottom options better in view. */
  /* Also indicates end of option list. */


### PR DESCRIPTION
Finalized Makefile, adding target "manoptionsdump.gen" that builds option links from perl script; _option-menu.html, editing embedded CSS to better width/heights; _manpage.html, changing "\#include _manoptionsdump.html" to "\#include manoptionsdump.gen".